### PR TITLE
Remove timeout from update

### DIFF
--- a/openag_binary_actuator.cpp
+++ b/openag_binary_actuator.cpp
@@ -3,7 +3,6 @@
 BinaryActuator::BinaryActuator(int pin, bool is_active_low) {
   _pin = pin;
   _is_active_low = is_active_low;
-  _last_cmd = 0;
 }
 
 void BinaryActuator::begin() {
@@ -16,20 +15,9 @@ void BinaryActuator::begin() {
   }
 }
 
-void BinaryActuator::update() {
-  uint32_t curr_time = millis();
-  if ((curr_time - _last_cmd) > _max_update_interval) {
-    if (_is_active_low) {
-      digitalWrite(_pin, HIGH);
-    }
-    else {
-      digitalWrite(_pin, LOW);
-    }
-  }
-}
+void BinaryActuator::update() {}
 
 void BinaryActuator::set_cmd(std_msgs::Bool cmd) {
-  _last_cmd = millis();
   if (cmd.data ^ _is_active_low) {
     digitalWrite(_pin, HIGH);
   }

--- a/openag_binary_actuator.h
+++ b/openag_binary_actuator.h
@@ -19,8 +19,6 @@ class BinaryActuator : public Module {
     // Private variables
     int _pin;
     bool _is_active_low;
-    uint32_t _last_cmd;
-    const static int _max_update_interval = 10000;
 };
 
 #endif


### PR DESCRIPTION
Actuator currently turns off after 10s automatically. This removes the reset timeout from actuator update method.

Tested on Arduino Mega.
